### PR TITLE
Setup systemctl service with Flask app.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,8 +10,6 @@ from app.database.models.post import Post
 
 app = Flask(__name__)
 database = Database.get_instance()
-
-database.connect()
 database.create_tables([Post])
 
 @app.route('/')

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,6 @@ import os
 import json
 
 from flask import Flask, render_template, request, redirect
-from peewee import MySQLDatabase
 from playhouse.shortcuts import model_to_dict
 
 from app.database.lib import Database

--- a/app/database/lib.py
+++ b/app/database/lib.py
@@ -4,7 +4,6 @@ from peewee import MySQLDatabase
 
 class Database(object):
   _instance = None
-  db: MySQLDatabase = None
 
   def __init__(self):
     raise RuntimeError("call get_instance() instead.")
@@ -12,13 +11,13 @@ class Database(object):
   @classmethod
   def get_instance(cls):
     if not cls._instance:
-      cls._instance = cls.__new__(cls)
-      cls.db = MySQLDatabase(
+      cls._instance = MySQLDatabase(
         database=SecretsManager.get_env("MYSQL_DATABASE"),
         user=SecretsManager.get_env("MYSQL_USER"),
         password=SecretsManager.get_env("MYSQL_PASSWORD"),
         host=SecretsManager.get_env("MYSQL_HOST"),
         port=3306
       )
+      cls._instance.connect()
 
-    return cls.db
+    return cls._instance

--- a/app/scripts/redeploy.sh
+++ b/app/scripts/redeploy.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# Reset environment and update project.
-tmux kill-server;
-cd "~/repos/project-placeholder";
+cd ~/repos/project-placeholder;
 git stash && git switch main && git fetch --all && git reset --hard origin/main;
-
-# Boot process.
-tmux new-session -d -s process "cd ~/repos/project-placeholder && source venv/bin/activate && pip install -q -r requirements.txt && flask run --host=0.0.0.0";
+source venv/bin/activate;
+pip install -q -r requirements.txt;


### PR DESCRIPTION
## Description

Refactor application to be served using a systemctl service instead of a tmux session. Tmux commands in `redeploy.sh` aren't needed.

## Tasks

- Remove tmux commands from `redeploy.sh`.
- Refactor database connection inside the `Database` singleton class.

## Resources and screenshots (optional)

- [More on systemd and systemctl](https://blog.miguelgrinberg.com/post/running-a-flask-application-as-a-service-with-systemd).
- [Running flask as a systemctl service](https://stackoverflow.com/questions/60401049/start-a-flask-via-systemd-service).
