### PR TITLE
feature(nginx): set up rate limit directive.

### DIFF
--- a/user_conf.d/projectplaceholder.conf
+++ b/user_conf.d/projectplaceholder.conf
@@ -12,10 +12,12 @@ server {
 server {
   listen 443 ssl;
   server_name osdavrm.duckdns.org;
-  location /api/create_post {
+  location ^~ /api/ {
     limit_req zone=one;
-    proxy_next_upstream error http_403 non_idempotent;
-    proxy_next_upstream error http_502 non_idempotent;
+    proxy_pass http://projectplaceholder:5000/api/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
   location / {
     proxy_pass http://projectplaceholder:5000/;

--- a/user_conf.d/projectplaceholder.conf
+++ b/user_conf.d/projectplaceholder.conf
@@ -1,3 +1,6 @@
+limit_req_zone $binary_remote_addr zone=one:10m rate=10r/s;
+limit_req_status 429;
+
 server {
   listen 80;
   server_name osdavrm.duckdns.org;
@@ -9,6 +12,11 @@ server {
 server {
   listen 443 ssl;
   server_name osdavrm.duckdns.org;
+  location /api/create_post {
+    limit_req zone=one;
+    proxy_next_upstream error http_403 non_idempotent;
+    proxy_next_upstream error http_502 non_idempotent;
+  }
   location / {
     proxy_pass http://projectplaceholder:5000/;
   }


### PR DESCRIPTION
## Description

Set NGINX rules to rate limit the portfolio's API endpoints.

## Tasks

- Research on rate-limiting techniques in NGINX
- Implement rate limit directives in NGINX config.

## Resources and screenshots (optional)

- [Stackoverflow solution](https://stackoverflow.com/a/50633094/11672866).
- [Leaky bucket algorithm](https://en.wikipedia.org/wiki/Leaky_bucket).
- [Rate-limiting with NGINX](https://www.nginx.com/blog/rate-limiting-nginx/).
- [Stress testing command to query endpoints](https://stackoverflow.com/a/57182755/11672866).
  - `seq 1 200 | xargs -n1 -P10  curl ...`: Run curl command 200 times with max 10 jobs in parallel.